### PR TITLE
Improved types for IPowerLevelsContent and hasSufficientPowerLevelFor

### DIFF
--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -60,6 +60,8 @@ export interface IPowerLevelsContent {
     // eslint-disable-next-line camelcase
     state_default?: number;
     ban?: number;
+    historical?: number;
+    invite?: number;
     kick?: number;
     redact?: number;
 }
@@ -800,7 +802,7 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
      * @param powerLevel - The power level of the member
      * @returns true if the given power level is sufficient
      */
-    public hasSufficientPowerLevelFor(action: "ban" | "kick" | "redact", powerLevel: number): boolean {
+    public hasSufficientPowerLevelFor(action: keyof Omit<IPowerLevelsContent, "events" | "users">, powerLevel: number): boolean {
         const powerLevelsEvent = this.getStateEvents(EventType.RoomPowerLevels, "");
 
         let powerLevels: IPowerLevelsContent = {};


### PR DESCRIPTION
while developing to use the hasSufficientPowerLevelFor method i logged the contents of a EventType.RoomPowerLevels state event for a room and found there were missing properties, which i add in this PR